### PR TITLE
fix the example code in czmq.txt

### DIFF
--- a/doc/czmq.txt
+++ b/doc/czmq.txt
@@ -237,9 +237,9 @@ These are the places a C application is subject to arbitrary system differences:
 An example of the last:
 ----
     #if (defined (__UNIX__))
-        pid = GetCurrentProcessId();
+        pid = getpid();
     #elif (defined (__WINDOWS__))
-        pid = getpid ();
+        pid = GetCurrentProcessId();
     #else
         pid = 0;
     #endif


### PR DESCRIPTION


# Pull Request Notice


```
Problem: czmq.txt (7) line#238-246 has typo 

Solution: should be replaced by
----
    #if (defined (__UNIX__))
        pid = getpid();
    #elif (defined (__WINDOWS__))
        pid = GetCurrentProcessId();
    #else
        pid = 0;
    #endif
----
```
